### PR TITLE
Add cross-model performance curves comparison

### DIFF
--- a/mlpipe/mlpipe.py
+++ b/mlpipe/mlpipe.py
@@ -5,8 +5,8 @@ import time
 import os
 import torch
 from torch.utils.data import DataLoader
-from sklearn import metrics
 import numpy as np
+from matplotlib import pyplot as plt
 
 from .data import Dataset, truncate_collate
 from .report import Report
@@ -211,14 +211,28 @@ class MLPipe(object):
         y_truth = np.hstack(labels)
 
         print("Saving validation data...")
+        # Creating cross model roc and pr comparison plot
+        roc_fig, roc_ax = plt.subplots(1,1)
         for name in self._models.keys():
             y_pred = np.hstack(predictions[name])
             y_pred_proba = np.vstack(probas[name])
             time_spent = sum(time_dict[name])
             self._report.add_record(name, self._epoch, self._batch,
                                     y_pred, y_pred_proba, y_truth,
-                                    time_spent)
+                                    time_spent, roc_ax=roc_ax)
 
+        roc_ax.set_title("ROC Curves") 
+        roc_ax.set_xlabel("False Positive Rate")
+        roc_ax.set_ylabel("True Positive Rate")
+        roc_ax.plot([0, 1], [0, 1], 'k--', lw=2)
+        roc_ax.set_xlim([0.0, 1.0])
+        roc_ax.set_ylim([0.0, 1.05])
+        roc_ax.legend()
+        # saving roc plot
+        filename = os.path.join(self._output_dir, "all_roc_curve.png")
+        print("Saving plot: %s" % filename)
+        roc_fig.savefig(filename)
+        
         # print a intermediate result
         print('')
         print('== VALIDATION RESULTS: ==')

--- a/mlpipe/mlpipe.py
+++ b/mlpipe/mlpipe.py
@@ -213,14 +213,15 @@ class MLPipe(object):
         print("Saving validation data...")
         # Creating cross model roc and pr comparison plot
         roc_fig, roc_ax = plt.subplots(1,1)
+        pr_fig, pr_ax = plt.subplots(1,1)
         for name in self._models.keys():
             y_pred = np.hstack(predictions[name])
             y_pred_proba = np.vstack(probas[name])
             time_spent = sum(time_dict[name])
             self._report.add_record(name, self._epoch, self._batch,
                                     y_pred, y_pred_proba, y_truth,
-                                    time_spent, roc_ax=roc_ax)
-
+                                    time_spent, roc_ax=roc_ax, pr_ax=pr_ax)
+        # Save ROC curves
         roc_ax.set_title("ROC Curves") 
         roc_ax.set_xlabel("False Positive Rate")
         roc_ax.set_ylabel("True Positive Rate")
@@ -228,10 +229,22 @@ class MLPipe(object):
         roc_ax.set_xlim([0.0, 1.0])
         roc_ax.set_ylim([0.0, 1.05])
         roc_ax.legend()
-        # saving roc plot
         filename = os.path.join(self._output_dir, "all_roc_curve.png")
         print("Saving plot: %s" % filename)
         roc_fig.savefig(filename)
+        plt.close(roc_fig)
+
+        # Save PR curves
+        pr_ax.set_title("Precision-Recall Curves") 
+        pr_ax.set_xlabel("Recall")
+        pr_ax.set_ylabel("Precision")
+        pr_ax.set_xlim([0.0, 1.0])
+        pr_ax.set_ylim([0.0, 1.05])
+        pr_ax.legend()
+        filename = os.path.join(self._output_dir, "all_pr_curve.png")
+        print("Saving plot: %s" % filename)
+        pr_fig.savefig(filename)
+        plt.close(pr_fig)
         
         # print a intermediate result
         print('')

--- a/mlpipe/report.py
+++ b/mlpipe/report.py
@@ -78,7 +78,16 @@ class Report(object):
                 roc_ax.plot(fpr, tpr, label='{0} (area = {1:0.2f})'.format(model_name, roc_auc),
                             linestyle=':', linewidth=4)
                 roc_ax.set_xlabel("False Positive Rate")
-
+            if pr_ax:
+                truth_binarize = to_categorical(truth, 2)
+                precision, recall, _ = metrics.precision_recall_curve(
+                    truth_binarize.ravel(), proba.ravel())
+                average_precision = metrics.average_precision_score(truth_binarize,
+                                                                    proba,
+                                                                    average='micro')
+                pr_ax.plot(recall, precision,
+                           label='{0} (area = {1:0.3f})'.format(model_name, average_precision),
+                           linestyle=':', linewidth=4)
 
     def print_batch_report(self, epoch, batch):
         report = self.report

--- a/mlpipe/utils.py
+++ b/mlpipe/utils.py
@@ -1,0 +1,5 @@
+import numpy as np
+
+def to_categorical(y, num_classes):
+    """ 1-hot encodes a tensor """
+    return np.eye(num_classes, dtype='uint8')[y]


### PR DESCRIPTION
The performance curves were restricted to per model before, this PR aims to automatically generate 
cross model ROC curves and precision-recall curves. 